### PR TITLE
format the Usage code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,62 +24,61 @@ $ npm install vue-datepicker
 # Usage
 
 ```html
-<!-- your component -->
 <script>
 import myDatepicker from 'vue-datepicker'
 export default {
-  data() {
-      return {
-        starttime: '',
-        endtime: '2016-01-19',
-        testTime: '',
-        option: {
-          type: 'day',
-          week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
-          month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-          format:'YYYY-MM-DD',
-          placeholder: 'when?',
-          inputStyle: {
-            'display': 'inline-block',
-            'padding': '6px',
-            'line-height': '22px',
-            'font-size': '16px',
-            'border': '2px solid #fff',
-            'box-shadow': '0 1px 3px 0 rgba(0, 0, 0, 0.2)',
-            'border-radius': '2px',
-            'color': '#5F5F5F'
-          },
-          color: {
-            header: '#ccc',
-            headerText: '#f00'
-          },
-          buttons : {
-            ok : 'Ok',
-            cancel : 'Cancel'
-          },
-          overlayOpacity : 0.5, //0.5 as default
-          dismissible : true //as true as default
+  data () {
+    return {
+      starttime: '',
+      endtime: '2016-01-19',
+      testTime: '',
+      option: {
+        type: 'day',
+        week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+        month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+        format: 'YYYY-MM-DD',
+        placeholder: 'when?',
+        inputStyle: {
+          'display': 'inline-block',
+          'padding': '6px',
+          'line-height': '22px',
+          'font-size': '16px',
+          'border': '2px solid #fff',
+          'box-shadow': '0 1px 3px 0 rgba(0, 0, 0, 0.2)',
+          'border-radius': '2px',
+          'color': '#5F5F5F'
         },
-        timeoption: {
-          type: 'min',
-          week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
-          month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-          format:"YYYY-MM-DD HH:mm"
+        color: {
+          header: '#ccc',
+          headerText: '#f00'
         },
-        limit:[{
-            type: 'weekday',
-            available: [1,2,3,4,5]
-          },
-          {
-           type:'fromto',
-           from:'2016-02-01',
-           to:'2016-02-20'
-          }]
-      }
-    },
-    components: {
-      'date-picker': myDatepicker
+        buttons: {
+          ok: 'Ok',
+          cancel: 'Cancel'
+        },
+        overlayOpacity: 0.5, // 0.5 as default
+        dismissible: true // as true as default
+      },
+      timeoption: {
+        type: 'min',
+        week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+        month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+        format: 'YYYY-MM-DD HH:mm'
+      },
+      limit: [{
+        type: 'weekday',
+        available: [1, 2, 3, 4, 5]
+      },
+      {
+        type: 'fromto',
+        from: '2016-02-01',
+        to: '2016-02-20'
+      }]
     }
+  },
+  components: {
+    'date-picker': myDatepicker
+  }
 }
 </script>
 <template>
@@ -104,8 +103,6 @@ export default {
   </div>
   <input type="time">
 </template>
-
-
 ```
 
 # API


### PR DESCRIPTION
When I use the Usage code in [vue-cli](https://github.com/vuejs/vue-cli), it can not pass the check of JSHint.
I format it to make it work well in vue-cli.
