### PR TITLE
remove enforce of roboto font

### DIFF
--- a/vue-datepicker.vue
+++ b/vue-datepicker.vue
@@ -485,7 +485,6 @@ exports.default = {
   overflow: hidden;
   position: relative;
   font-size: 16px;
-  font-family: 'Roboto';
   font-weight: 400;
   position: fixed;
   display: block;
@@ -704,7 +703,6 @@ table {
   border: 2px solid #fff;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
   border-radius: 2px;
-  font-family: 'Roboto';
   color: #5F5F5F;
 }
 


### PR DESCRIPTION
this font is not a dependency and fallback to browser default font unless it is manually loaded.
