### PR TITLE
Fix : $remove function not supported in vuejs 2.x

### DIFF
--- a/vue-datepicker.vue
+++ b/vue-datepicker.vue
@@ -652,7 +652,8 @@ exports.default = {
         var ctime = this.checked.year + '-' + this.checked.month + '-' + day;
         if (obj.checked === true) {
           obj.checked = false;
-          this.selectedDays.$remove(ctime);
+          var index = this.selectedDays.indexOf(ctime)
+          this.selectedDays.splice(index, 1)
         } else {
           this.selectedDays.push(ctime);
           obj.checked = true;


### PR DESCRIPTION
Hi,

Here is a fix for a bug appear when unselect a date in a multi-day with last version of vuejs 2.1.x 
```
Uncaught TypeError: this.selectedDays.$remove is not a function(…)
```