### PR TITLE
Add default date prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ export default {
 
 # API
 
- - Option 
+ - Option
 
  * type
 
@@ -217,8 +217,18 @@ limit: {
 
 limit:{
   type: 'weekday',
-  available: [1, 2, 3, 4, 5] 
+  available: [1, 2, 3, 4, 5]
 }
+
+```
+
+- defaultDate
+
+  * if you need to set up a default date other than today, you can pass it on with the `default-date` prop
+
+```javascript
+
+defaultDate: '1970-01-01'
 
 ```
 
@@ -248,7 +258,7 @@ date: {
 
 ```html
 
-<date-picker :date="date" :limit="limit"></date-picker>
+<date-picker :date="date" :limit="limit" :default-date="defaultDate"></date-picker>
 
 ```
 
@@ -256,4 +266,3 @@ date: {
 # License
 
 [The MIT License](http://opensource.org/licenses/MIT)
-

--- a/vue-datepicker.vue
+++ b/vue-datepicker.vue
@@ -432,6 +432,9 @@ exports.default = {
       default: function _default() {
         return [];
       }
+    },
+    defaultDate: {
+      type: String
     }
   },
   data: function data() {
@@ -503,7 +506,7 @@ exports.default = {
     },
     showDay: function showDay(time) {
       if (time === undefined || !Date.parse(time)) {
-        this.checked.currentMoment = (0, _moment2.default)();
+        this.checked.currentMoment = (0, _moment2.default)(this.defaultDate);
       } else {
         this.checked.currentMoment = (0, _moment2.default)(time, this.option.format);
       }


### PR DESCRIPTION
Hi
I'm using this datepicker on a project where I needed to be able to set a custom default date for the picker (so if the user is choosing something like their birth date, they don't have to scroll all the way from 2016). So I added a defaultDate prop, that sets the `checked.currentMoment` to that date if present, otherwise it defaults to current time.
If you feel like that's something other people would like to use, feel free to add it :)
