### PR TITLE
added locale option for moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ export default {
 
       option: {
         type: 'day',
+        locale: 'en',
         week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
         month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
         format: 'YYYY-MM-DD',
@@ -123,7 +124,7 @@ export default {
 
 # API
 
- - Option 
+ - Option
 
  * type
 
@@ -136,6 +137,12 @@ export default {
 
 ```
 format: 'YYYY-MM-DD HH:mm'
+```
+
+ * locale
+
+```
+locale: 'en'
 ```
 
  * placeholder
@@ -228,7 +235,7 @@ limit: {
 
 limit:{
   type: 'weekday',
-  available: [1, 2, 3, 4, 5] 
+  available: [1, 2, 3, 4, 5]
 }
 
 ```
@@ -267,4 +274,3 @@ date: {
 # License
 
 [The MIT License](http://opensource.org/licenses/MIT)
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-datepicker",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "calendar and datepicker component with material design for Vue.js ",
   "main": "vue-datepicker.vue",
   "scripts": {

--- a/vue-datepicker-1.vue
+++ b/vue-datepicker-1.vue
@@ -454,6 +454,7 @@ exports.default = {
         return {
           type: 'day',
           SundayFirst: false,
+          locale: 'en',
           week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
           month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
           format: 'YYYY-MM-DD',
@@ -882,6 +883,9 @@ exports.default = {
         document.querySelector('.min-box').scrollTop = (document.querySelector('.min-item.active').offsetTop || 0) - 250;
       });
     }
+  },
+  created: function created() {
+      (0, _moment2.default).locale(this.option.locale);
   }
 };
 </script>

--- a/vue-datepicker-es6.vue
+++ b/vue-datepicker-es6.vue
@@ -386,6 +386,7 @@ export default {
         return {
           type: 'day',
           SundayFirst: false,
+          locale: 'en',
           week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
           month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
           format: 'YYYY-MM-DD',
@@ -762,6 +763,9 @@ export default {
         document.querySelector('.min-box').scrollTop = (document.querySelector('.min-item.active').offsetTop || 0) - 250
       })
     }
+  },
+  created() {
+    moment.locale(this.option.locale);
   }
 }
 </script>

--- a/vue-datepicker.es6-1.vue
+++ b/vue-datepicker.es6-1.vue
@@ -438,6 +438,7 @@ export default {
         return {
           type: 'day',
           SundayFirst: false,
+          locale: 'en',
           week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
           month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
           format: 'YYYY-MM-DD',
@@ -815,6 +816,9 @@ export default {
         document.querySelector('.min-box').scrollTop = (document.querySelector('.min-item.active').offsetTop || 0) - 250
       })
     }
+  },
+  created() {
+    moment.locale(this.option.locale);
   }
 }
 </script>

--- a/vue-datepicker.vue
+++ b/vue-datepicker.vue
@@ -397,6 +397,7 @@ exports.default = {
         return {
           type: 'day',
           SundayFirst: false,
+          locale: 'en',
           week: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
           month: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
           format: 'YYYY-MM-DD',
@@ -825,6 +826,9 @@ exports.default = {
         document.querySelector('.min-box').scrollTop = (document.querySelector('.min-item.active').offsetTop || 0) - 250;
       });
     }
+  },
+  created: function created() {
+    (0, _moment2.default).locale(this.option.locale);
   }
 };
 </script>


### PR DESCRIPTION
I want to be able to specify which language moment should use. And you can utilize this even more. For example you can get all the month/week names from moment instead opt-in value.

```
const moment = require('moment');

moment.locale('sv'); // Swedish

moment.weekdays()

[ 'söndag',  'måndag',  'tisdag',  'onsdag',  'torsdag',  'fredag',  'lördag' ]

moment.weekdaysShort()

[ 'sön', 'mån', 'tis', 'ons', 'tor', 'fre', 'lör' ]

moment.months()

[ 'januari',  'februari',  'mars',  'april',  'maj',  'juni',  'juli',  'augusti',  'september',  'oktober',  'november',  'december' ]

moment.monthsShort()

[ 'jan',  'feb',  'mar',  'apr',  'maj',  'jun',  'jul',  'aug',  'sep',  'okt',  'nov',  'dec' ]
```

Best regards 
CG